### PR TITLE
Allow ERB in ebay_client.yml so that API secret keys can be set in ENV

### DIFF
--- a/lib/ebay_client/configuration.rb
+++ b/lib/ebay_client/configuration.rb
@@ -55,7 +55,7 @@ class EbayClient::Configuration
   class << self
     def load(file)
       defaults = load_defaults
-      configs = YAML.load_file file
+      configs = YAML.load(ERB.new(File.read(file)).result)
 
       configs.each_pair do |env, presets|
         env_defaults = defaults[env] || {}

--- a/spec/config/with_erb.yml
+++ b/spec/config/with_erb.yml
@@ -1,0 +1,8 @@
+test:
+  api_keys:
+    - token: <%= 'token' %>
+      devid: <%= 'devid' %>
+      appid: <%= 'appid' %>
+      certid: <%= 'certid' %>
+  preload: true
+  savon_log_level: :warn

--- a/spec/ebay_client/api_spec.rb
+++ b/spec/ebay_client/api_spec.rb
@@ -68,6 +68,22 @@ describe EbayClient::Api do
     end
   end
 
+  context 'with erb' do
+    before(:each) do
+      configuration = EbayClient::Configuration.load(File.expand_path('../../config/with_erb.yml', __FILE__))
+      configuration = configuration['test']
+      @api = EbayClient::Api.new configuration
+      @url = "https://api.sandbox.ebay.com/wsapi?appid=#{configuration.appid}&callname=GeteBayOfficialTime&routing=#{configuration.routing}&siteid=#{configuration.siteid}&version=#{configuration.version}"
+    end
+
+    it 'should load the erb-based configuration values' do
+      expect(@api.configuration.api_keys.first.token).to eq('token')
+      expect(@api.configuration.api_keys.first.devid).to eq('devid')
+      expect(@api.configuration.api_keys.first.appid).to eq('appid')
+      expect(@api.configuration.api_keys.first.certid).to eq('certid')
+    end
+  end
+
   def success_response
     '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'+
       '<soapenv:Body><GeteBayOfficialTimeResponse xmlns="urn:ebay:apis:eBLBaseComponents"><Timestamp>2009-10-11T12:13:14.000Z</Timestamp><Ack>Success</Ack>' +


### PR DESCRIPTION
ebay_client.yml can now look like (e.g.):

```
development: &ebay_env
  api_keys:
    - token: <%= ENV['EBAY_TOKEN'] %>
      devid: <%= ENV['EBAY_DEV_ID'] %>
      appid: <%= ENV['EBAY_APP_ID'] %>
      certid: <%= ENV['EBAY_CERT_ID'] %>

test:
  <<: *ebay_env

production:
  <<: *ebay_env
```

Which allows us to set our eBay API secrets in environment variables rather than checking them into our git repo.

Addresses Issue #13 