### PR TITLE
Fall back to development if the rails_env does not exist

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -20,6 +20,9 @@ development: &development
 test:
   <<: *development
 
+staging:
+  <<: *development
+
 production:
   <<: *defaults
   url: 'https://api.ebay.com/wsapi'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -20,9 +20,6 @@ development: &development
 test:
   <<: *development
 
-staging:
-  <<: *development
-
 production:
   <<: *defaults
   url: 'https://api.ebay.com/wsapi'

--- a/lib/ebay_client/configuration.rb
+++ b/lib/ebay_client/configuration.rb
@@ -58,7 +58,7 @@ class EbayClient::Configuration
       configs = YAML.load(ERB.new(File.read(file)).result)
 
       configs.each_pair do |env, presets|
-        env_defaults = defaults[env] || {}
+        env_defaults = defaults[env] || defaults['development']
         presets = presets || {}
 
         configs[env] = new env_defaults.merge(presets)


### PR DESCRIPTION
This adds a fallback to loading `development` env vars if the `rails_env` does not exist in `defaults.yml` 

This allows for testing the ebay client on staging environments.